### PR TITLE
Dialog detail enhancements

### DIFF
--- a/delayed-action-card.js
+++ b/delayed-action-card.js
@@ -549,6 +549,8 @@ function getEntityActions(entityId) {
     start_mowing: "Start Mowing",
     select_option: "Select Option",
   };
+  const state = document.querySelector("home-assistant")?.hass.states[entityId].state;
+  let defaultIndex;
 
   switch (entityId.split(".")[0]) {
     case "light":
@@ -560,6 +562,7 @@ function getEntityActions(entityId) {
     case "siren":
     case "water_heater":
       result = ["turn_on", "turn_off", "toggle"];
+      defaultIndex = state === "on" ? 1 : 0;
       break;
     case "media_player":
       result = [
@@ -590,6 +593,7 @@ function getEntityActions(entityId) {
       break;
     case "automation":
       result = ["turn_on", "turn_off", "trigger"];
+      defaultIndex = state === "on" ? 1 : 0;
       break;
     case "lawn_mower":
       result = ["dock", "pause", "start_mowing"];
@@ -602,7 +606,7 @@ function getEntityActions(entityId) {
       break;
   }
   return result
-    .map((action) => `<option value="${action}">${titles[action]}</option>`)
+    .map((action, i) => `<option value="${action}"${i === defaultIndex ? " selected" : ""}>${titles[action]}</option>`)
     .join("");
 }
 

--- a/delayed-action-card.js
+++ b/delayed-action-card.js
@@ -265,7 +265,7 @@ function cardElements(element, hass, config, offset, additionalClass) {
     e.preventDefault();
     e.stopPropagation();
     //timerDialog.style.display = "block";
-    openDialog(hass, config.entity);
+    openDialog(hass, config.entity, e.target.classList.contains("blink"));
   });
 
   cornerButton.addEventListener("mousedown", (e) => {
@@ -606,7 +606,7 @@ function getEntityActions(entityId) {
     .join("");
 }
 
-function openDialog(hass, entityId) {
+function openDialog(hass, entityId, alreadyScheduled) {
   const dialog = document.createElement("ha-dialog");
   dialog.open = true;
 
@@ -717,7 +717,9 @@ function openDialog(hass, entityId) {
             width: 100%;
           }
         </style>
-        <div class="custom-dialog-content">
+        <div class="custom-dialog-content">` + (
+          alreadyScheduled ? "<label style='color: var(--accent-color);'>(Schedule already set)</label>" : ""
+        ) + `
           <label for="delayAction">Action</label>
           <select id="delayAction">` + getEntityActions(entityId) + `</select>` + selectOptions + `
           <label for="delayTime">Delay for</label>

--- a/delayed-action-card.js
+++ b/delayed-action-card.js
@@ -616,7 +616,7 @@ function openDialog(hass, entityId, alreadyScheduled) {
   dialogHeader.style.alignItems = "start";
   dialogHeader.innerHTML = `
       <ha-icon-button id="closeButton" style="background: none; border: none; font-size: 36px; cursor: pointer;">&times;</ha-icon-button>
-      <p style="margin: 9px 0 0 0" title='Delayed Action'>Delayed Action</p>
+      <p style="margin: 9px 0 0 0" title='Delayed Action'>Delayed Action: ${hass.entities[entityId].name ?? entityId}</p>
     `;
   dialog.heading = dialogHeader;
 


### PR DESCRIPTION
This PR:
- Adds a warning to the delayed action dialog, if an action is already scheduled
- Shows the entity name or ID on the delayed action card
- Selects a sensible default based on the entity's current state (entity off -> prefill with "turn on", and vice versa)